### PR TITLE
Ensure forced exit on errors

### DIFF
--- a/portal_dryrun_forecast.sh
+++ b/portal_dryrun_forecast.sh
@@ -24,7 +24,7 @@ git clone https://github.com/weecology/portal-forecasts.git
 cd portal-forecasts
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Running Portal Forecasts"
-singularity run ../portalcasting_latest.sif Rscript PortalForecasts_dryrun.R
+singularity run ../portalcasting_latest.sif Rscript PortalForecasts_dryrun.R  2>&1 || exit 1
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Checking if forecasts were successful"
 # Redirect stderr(2) to stdout(1) if command fails, and exit script with 1

--- a/portal_weekly_forecast.sh
+++ b/portal_weekly_forecast.sh
@@ -24,7 +24,7 @@ git clone https://github.com/weecology/portal-forecasts.git
 cd portal-forecasts
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Running Portal Forecasts"
-singularity run ../portalcasting_latest.sif Rscript PortalForecasts.R
+singularity run ../portalcasting_latest.sif Rscript PortalForecasts.R  2>&1 || exit 1
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Checking if forecasts were successful"
 # Redirect stderr(2) to stdout(1) if command fails, and exit script with 1


### PR DESCRIPTION
To prevent the archiving of incorrect files, both
PortalForecasts_dryrun.R and PortalForecasts.R 
should terminate execution immediately upon encountering errors.

#7 