### PR TITLE
Evaluate all forecasts made when on dry runs

### DIFF
--- a/PortalForecasts_dryrun.R
+++ b/PortalForecasts_dryrun.R
@@ -9,7 +9,7 @@ setup_production()
 portalcast(models = c("ESSS", "pevGARCH"))
 
 #Evaluate model forecast
-evaluate_forecast()
+evaluate_forecasts()
 
 #Zip all forecasts files and evaluation
 post_process()


### PR DESCRIPTION
A typo leaving off an `s` meant that we weren't running the correct function.
This matches up with the main forecast run.