### PR TITLE
Add environment selection for Zenodo sandbox vs production

### DIFF
--- a/PortalForecasts.R
+++ b/PortalForecasts.R
@@ -1,5 +1,8 @@
 library(portalcasting)
 
+# Set environment variable for production token
+Sys.setenv(ZENODOENV = "production")
+
 #Downloading the full production archive is slow
 options(timeout=600)
 

--- a/PortalForecasts_dryrun.R
+++ b/PortalForecasts_dryrun.R
@@ -2,6 +2,9 @@ library(portalr)
 sessionInfo()
 library(portalcasting)
 
+# Set environment variable for sandbox token
+Sys.setenv(ZENODOENV = "sandbox")
+
 #Update data and models
 setup_production()
 

--- a/archive_hipergator.sh
+++ b/archive_hipergator.sh
@@ -4,7 +4,14 @@
 
 current_date=`date -I | head -c 10`
 
-source /blue/ewhite/hpc_maintenance/githubdeploytoken.txt
+# Source the appropriate token based on environment variable
+if [ "$ZENODOENV" = "sandbox" ]; then
+    echo "Using Zenodo sandbox environment"
+    source /blue/ewhite/hpc_maintenance/zenodosandboxtoken.txt
+else
+    echo "Using Zenodo production environment"
+    source /blue/ewhite/hpc_maintenance/githubdeploytoken.txt
+fi
 
 # Copy version of portal_weekly_forecast.py used to run the forecast into the repo so we know what was run
 cp ../portal_weekly_forecast.sh .

--- a/portal_dryrun_forecast.sh
+++ b/portal_dryrun_forecast.sh
@@ -11,6 +11,8 @@
 echo "INFO: [$(date "+%Y-%m-%d %H:%M:%S")] Starting Weekly Forecast on $(hostname) in $(pwd)"
 cd /orange/ewhite/PortalForecasts/
 
+# Set environment variable for sandbox token
+export ZENODOENV="sandbox"
 source /blue/ewhite/hpc_maintenance/zenodosandboxtoken.txt
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Loading required modules"
@@ -34,3 +36,6 @@ singularity run ../portalcasting_latest.sif Rscript PortalForecasts_dryrun.R  2>
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Checking if forecasts were successful"
 # Redirect stderr(2) to stdout(1) if command fails, and exit script with 1
 singularity run ../portalcasting_latest.sif Rscript tests/testthat/test-successful_forecasts.R > ../testthat.log 2>&1 || exit 1
+
+echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Archiving to GitHub and Zenodo"
+singularity run --env ZENODOENV=$ZENODOENV ../portalcasting_latest.sif bash archive_hipergator.sh

--- a/portal_weekly_forecast.sh
+++ b/portal_weekly_forecast.sh
@@ -11,6 +11,8 @@
 echo "INFO: [$(date "+%Y-%m-%d %H:%M:%S")] Starting Weekly Forecast on $(hostname) in $(pwd)"
 cd /orange/ewhite/PortalForecasts/
 
+# Set environment variable for production token
+export ZENODOENV="production"
 source /blue/ewhite/hpc_maintenance/githubdeploytoken.txt
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Loading required modules"
@@ -22,6 +24,7 @@ singularity pull --force docker://weecology/portalcasting
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Updating portal-forecasts repository"
 rm -rf portal-forecasts
+
 git clone https://github.com/weecology/portal-forecasts.git
 cd portal-forecasts
 
@@ -35,7 +38,7 @@ echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Checking if forecasts were successful"
 singularity run ../portalcasting_latest.sif Rscript tests/testthat/test-successful_forecasts.R > ../testthat.log 2>&1 || exit 1
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Archiving to GitHub and Zenodo"
-singularity run ../portalcasting_latest.sif bash archive_hipergator.sh
+singularity run --env ZENODOENV=$ZENODOENV ../portalcasting_latest.sif bash archive_hipergator.sh
 
 echo "INFO [$(date "+%Y-%m-%d %H:%M:%S")] Checking if archiving to GitHub was successful"
 singularity run ../portalcasting_latest.sif Rscript tests/testthat/test-forecasts_committed.R > ../testthat.log 2>&1 || exit 1


### PR DESCRIPTION
- Use ZENODOENV env sandbox and production to pick right token
- Set ZENODOENV=sandbox in PortalForecasts_dryrun.R for testing
- Set ZENODOENV=production in PortalForecasts.R for live runs
- Add --env ZENODOENV flag to Singularity archive commands only
- Use zenodosandboxtoken.txt for dry runs, githubdeploytoken.txt for production